### PR TITLE
Add warnings on README for python 2.7 compatibility

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -27,11 +27,8 @@ To install via pip, type the following:
 >>> pip install vollib
 ```
 
-For Python3 install via pip, type the following:
-
-```
->>> pip install py-vollib
-```
+> **Warning**
+> This library is only compatible with python2.7. Please see the updated library here - https://github.com/vollib/py_vollib
 
 Installing `vollib` via pip will automatically install the necessary dependencies,
 except for SWIG, pip, and Python.  This has been tested to work on Windows, Linux and Macintosh OS X.

--- a/README.MD
+++ b/README.MD
@@ -24,6 +24,12 @@ To install via pip, type the following:
 >>> pip install vollib
 ```
 
+For Python3 install via pip, type the following:
+
+```
+>>> pip install py-vollib
+```
+
 Installing `vollib` via pip will automatically install the necessary dependencies,
 except for SWIG, pip, and Python.  This has been tested to work on Windows, Linux and Macintosh OS X.
 

--- a/README.MD
+++ b/README.MD
@@ -1,3 +1,6 @@
+> **Warning**
+> This library is only compatible with python2.7. Please see the updated library here - https://github.com/vollib/py_vollib
+
 # `vollib`
 
 `vollib` is a python library for calculating option prices, 


### PR DESCRIPTION
It is not immediately clear from the README that this library is only compatible with python 2.7 and not python 3.

It is also not obvious where the updated version of this library is. 

I added two warnings (one on top and one near the pip install section) to point to the updated library.